### PR TITLE
added button Reset Overrides for filters

### DIFF
--- a/pyChilizer.tab/Project.panel/colorizers2.stack/Reset Filters.pulldown/Reset Overrides.pushbutton/bundle.yaml
+++ b/pyChilizer.tab/Project.panel/colorizers2.stack/Reset Filters.pulldown/Reset Overrides.pushbutton/bundle.yaml
@@ -1,0 +1,4 @@
+title: "Reset Overrides"
+tooltip: |
+  Remove all graphic overrides for selected filters in the active view.
+  Author: Daria Ivanciucova

--- a/pyChilizer.tab/Project.panel/colorizers2.stack/Reset Filters.pulldown/Reset Overrides.pushbutton/script.py
+++ b/pyChilizer.tab/Project.panel/colorizers2.stack/Reset Filters.pulldown/Reset Overrides.pushbutton/script.py
@@ -12,32 +12,8 @@ view_filter_ids = view.GetFilters()
 
 
 def overrides_reset():
-
     # returns Override Graphic Settings object with all overrides set to initial values
-    no_color = DB.Color.InvalidColorValue
-    invalid_id = DB.ElementId.InvalidElementId
-
     overrides = DB.OverrideGraphicSettings()
-    overrides.SetHalftone(False)
-    overrides.SetCutBackgroundPatternColor(no_color)
-    overrides.SetCutBackgroundPatternId(invalid_id)
-    overrides.SetCutForegroundPatternColor(no_color)
-    overrides.SetCutForegroundPatternId(invalid_id)
-    overrides.SetCutLineColor(no_color)
-    overrides.SetCutLinePatternId(invalid_id)
-    overrides.SetCutLineWeight(-1)
-    overrides.SetCutBackgroundPatternVisible(True)
-    overrides.SetCutForegroundPatternVisible(True)
-    overrides.SetSurfaceBackgroundPatternVisible(True)
-    overrides.SetSurfaceForegroundPatternVisible(True)
-    overrides.SetProjectionLineColor(no_color)
-    overrides.SetProjectionLinePatternId(invalid_id)
-    overrides.SetProjectionLineWeight(-1)
-    overrides.SetSurfaceBackgroundPatternColor(no_color)
-    overrides.SetSurfaceBackgroundPatternId(invalid_id)
-    overrides.SetSurfaceForegroundPatternColor(no_color)
-    overrides.SetSurfaceForegroundPatternId(invalid_id)
-    overrides.SetSurfaceTransparency(0)
     return overrides
 
 if view_filter_ids:

--- a/pyChilizer.tab/Project.panel/colorizers2.stack/Reset Filters.pulldown/Reset Overrides.pushbutton/script.py
+++ b/pyChilizer.tab/Project.panel/colorizers2.stack/Reset Filters.pulldown/Reset Overrides.pushbutton/script.py
@@ -1,0 +1,65 @@
+import sys
+
+from pyrevit import revit, DB
+from pyrevit import forms
+from pychilizer import database
+
+view = revit.active_view
+doc = revit.doc
+
+view_filter_ids = view.GetFilters()
+
+
+
+def overrides_reset():
+
+    # returns Override Graphic Settings object with all overrides set to initial values
+    no_color = DB.Color.InvalidColorValue
+    invalid_id = DB.ElementId.InvalidElementId
+
+    overrides = DB.OverrideGraphicSettings()
+    overrides.SetHalftone(False)
+    overrides.SetCutBackgroundPatternColor(no_color)
+    overrides.SetCutBackgroundPatternId(invalid_id)
+    overrides.SetCutForegroundPatternColor(no_color)
+    overrides.SetCutForegroundPatternId(invalid_id)
+    overrides.SetCutLineColor(no_color)
+    overrides.SetCutLinePatternId(invalid_id)
+    overrides.SetCutLineWeight(-1)
+    overrides.SetCutBackgroundPatternVisible(True)
+    overrides.SetCutForegroundPatternVisible(True)
+    overrides.SetSurfaceBackgroundPatternVisible(True)
+    overrides.SetSurfaceForegroundPatternVisible(True)
+    overrides.SetProjectionLineColor(no_color)
+    overrides.SetProjectionLinePatternId(invalid_id)
+    overrides.SetProjectionLineWeight(-1)
+    overrides.SetSurfaceBackgroundPatternColor(no_color)
+    overrides.SetSurfaceBackgroundPatternId(invalid_id)
+    overrides.SetSurfaceForegroundPatternColor(no_color)
+    overrides.SetSurfaceForegroundPatternId(invalid_id)
+    overrides.SetSurfaceTransparency(0)
+    return overrides
+
+if view_filter_ids:
+    filter_ids_dict = {}
+    # collect filters and get their names for the form
+    for filter_id in view_filter_ids:
+        filter_ids_dict[doc.GetElement(filter_id).Name] = filter_id
+    # ask which filters to override
+    selected_filter_names = forms.SelectFromList.show(sorted(filter_ids_dict,
+                       ),
+                                                 message="Select View Filters",
+                                                 multiselect="True",
+                                                 width=400)
+    if selected_filter_names:
+        with revit.Transaction ("Remove Filter Overrides"):
+            for filter_name in selected_filter_names:
+                filter=filter_ids_dict[filter_name]
+                overrides = overrides_reset()
+                view.SetFilterOverrides(filter, overrides)
+
+
+
+
+
+


### PR DESCRIPTION


## Description
Added a simple tool that reads the filters in the active view and, for selected filters, resets their overrides.

## Changes
Added 1 pushbutton to the Project > Reset Filters dropdown.


## Related Issues
None

## Checklist
- [x] Code follows the project's coding style
- [ ] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [ ] All automated tests are passing
- [ ] Reviewed by at least one team member

## Screenshots (if applicable)

![image](https://github.com/dnenov/pyChilizer/assets/43077096/dfa45183-263d-45a9-a18c-f495e18fd2f7)
![Remove overrides](https://github.com/dnenov/pyChilizer/assets/43077096/427de3ee-38ec-4173-8d07-ada70561273f)

## Additional Notes (if any)

