### PR TITLE
metric / imperial units fix

### DIFF
--- a/pyChilizer.tab/Template.panel/template2.stack/List Walls.pushbutton/script.py
+++ b/pyChilizer.tab/Template.panel/template2.stack/List Walls.pushbutton/script.py
@@ -11,17 +11,25 @@ doc = revit.doc
 view = revit.active_view
 
 # read previous configurations or use default
-line_length = walltypesconfig.get_config("line_length", doc)
-y_offset = walltypesconfig.get_config("y_offset", doc)
-x_offset = walltypesconfig.get_config("x_offset", doc)
-text_style_id = DB.ElementId(walltypesconfig.get_config("text_style"))
+LINE_LENGTH = 7.5  # wall length
+TEXT_OFFSET = 8.5
+COMPACT_OFFSET = 2.5
+SPACED_OFFSET = 5
+
+# -- Configuration settings --
+v_offset_choice = walltypesconfig.get_config("v_offset", doc)  # vertical offset choice between Compact and Spaced
+v_offset = COMPACT_OFFSET if v_offset_choice == "Compact" else SPACED_OFFSET
+text_bold_choice = walltypesconfig.get_config("text_bold")  # Bold text
+text_style_id = DB.ElementId(walltypesconfig.get_config("text_style"))  # Selected text style
 if not doc.GetElement(text_style_id):
     text_style_id = doc.GetDefaultElementTypeId(DB.ElementTypeGroup.TextNoteType)
-include_wall_buildup = walltypesconfig.get_config("include_buildup")
+include_wall_buildup = walltypesconfig.get_config("include_buildup")  # Buildup included
 
-def label_placer(text, point, text_style_id):
+
+# -- Helper Functions --
+def label_placer(text, point, t_style_id):
     point = point.Add(label_offset)
-    text_note = DB.TextNote.Create(doc, view.Id, point, text, text_style_id)
+    text_note = DB.TextNote.Create(doc, view.Id, point, text, t_style_id)
     return text_note
 
 
@@ -43,21 +51,35 @@ def get_level_from_view(view):
 
 def place_wall(loc, view_level):
     p1 = loc + DB.XYZ(0, -1, 0)
-    p2 = loc.Add(DB.XYZ(line_length, -1, 0))
+    p2 = loc.Add(DB.XYZ(LINE_LENGTH, -1, 0))
 
     curve = DB.Line.CreateBound(p1, p2)
     try:
         new_wall_element = DB.Wall.Create(doc, curve, view_level.Id, True)
         return new_wall_element
-    except:
+    except Exception as e:
+        print ("Error placing wall: {}".format(e))
         pass
 
 
-def change_wall_type(wall_element, wall_type):
+def change_wall_type(wall_element, w_type):
     try:
-       wall_element.WallType = wall_type
-    except:
-        return
+        wall_element.WallType = w_type
+    except Exception as e:
+        print("Error changing wall type for wall {} : {}".format(w_type.ToString(), e))
+        pass
+
+
+def format_wall_layers(wall_type, doc):
+    description = "\n\nTotal Thickness {}:".format(units.convert_length_to_display_string(wall_type.Width, doc))
+    wall_structure = wall_type.GetCompoundStructure()
+    if wall_structure:
+        for layer in wall_structure.GetLayers():
+            width = units.convert_length_to_display_string(layer.Width, doc)
+            material = doc.GetElement(layer.MaterialId)
+            material_name = material.Name if material else "ByCategory"
+            description += "\n\t- {} - {} - {}".format(width, layer.Function, material_name)
+    return description
 
 
 with forms.WarningBar(title="Pick Point"):
@@ -68,63 +90,55 @@ with forms.WarningBar(title="Pick Point"):
     except Exceptions.InvalidOperationException as ex:
         forms.alert("Error! {}".format(ex.Message), ok=True, exitscript=True)
 
-coll_wall_types = DB.FilteredElementCollector(doc)\
-    .OfCategory(BIC.OST_Walls)\
-    .OfClass(DB.WallType)\
+coll_wall_types = DB.FilteredElementCollector(doc) \
+    .OfCategory(BIC.OST_Walls) \
+    .OfClass(DB.WallType) \
     .WhereElementIsElementType()
 
 dict_walls = {}
 layers_count = {}
 
 for wall_type in coll_wall_types:
-    type_name = wall_type.get_Parameter(
-        DB.BuiltInParameter.ALL_MODEL_TYPE_NAME).AsString()
+    if wall_type.Kind.ToString() == "Basic":  # discard Curtain and Stacked walls
+        type_name = wall_type.get_Parameter(
+            DB.BuiltInParameter.ALL_MODEL_TYPE_NAME).AsString()
+        if include_wall_buildup:
+            type_name += format_wall_layers(wall_type, doc)
+            layers_count[type_name] = len(wall_type.GetCompoundStructure().GetLayers()) if wall_type.GetCompoundStructure() else 1
+        dict_walls.setdefault(type_name, wall_type)
 
-    if include_wall_buildup:
-        # format the description of the wall: Total Thickness and individual layer thickness and material
-        type_name += "\n\nTotal Thickness {}:".format(units.convert_length_to_display_string(wall_type.Width, doc))
-        wall_structure = wall_type.GetCompoundStructure()
-        if wall_structure:
-            layers = wall_structure.GetLayers()
-            for layer in layers:
-                layer_function = layer.Function
-                width = units.convert_length_to_display_string(layer.Width, doc)
-                material = doc.GetElement(layer.MaterialId)
-                if material:
-                    material_name = material.Name
-                else:
-                    material_name = "ByCategory" # if no material is assigned
-                type_name += "\n\t- {} - {} - {}".format(width, layer_function, material_name)
-            if type_name not in dict_walls.keys():
-                layers_count[type_name] = len(layers)
-    if type_name not in dict_walls.keys():
-        dict_walls[type_name] = wall_type
-
-label_offset = DB.XYZ(x_offset, 0, 0) # initial offset
+label_offset = DB.XYZ(TEXT_OFFSET, 0, 0)  # initial offset
 
 with revit.Transaction("Wall Types Legend"):
+    # for legend views - place legend components
     if view.ViewType == DB.ViewType.Legend:
         source_legend_component = DB.FilteredElementCollector(doc, view.Id).OfCategory(
             BIC.OST_LegendComponents).FirstElement()
         forms.alert_ifnot(source_legend_component,
-                          "The legend must have at least one source Legend Component to copy",
+                          "The legend must have at least one source Legend Component to copy. Please place any Legend "
+                          "Component on this legend (it can be deleted later).",
                           exitscript=True)
         source_bb = source_legend_component.get_BoundingBox(view)
-        initial_translation = - (source_bb.Max + source_bb.Min)/2
-
+        initial_translation = - (source_bb.Max + source_bb.Min) / 2
+    # for Floor Plan views
     elif view.ViewType == DB.ViewType.FloorPlan:
-
         level = get_level_from_view(view)
     for name in sorted(dict_walls):
-        try:
-            offset = DB.XYZ(0, -y_offset - layers_count[name], 0)
-        except KeyError:
-            offset = DB.XYZ(0, -y_offset, 0)
+        if include_wall_buildup:  # larger offset if Wall Buildup is included
+            if layers_count[name] == 1:
+                vertical_offset = v_offset * 1.5
+            else:
+                vertical_offset = v_offset * layers_count[name]
+        else:
+            vertical_offset = v_offset
+
+        offset = DB.XYZ(0, -vertical_offset, 0)
         header = label_placer(name, location, text_style_id)
-        set_bold(header)
+        if text_bold_choice == 1:
+            set_bold(header)
 
+        # for Legend views
         if view.ViewType == DB.ViewType.Legend:
-
             copy_component_id = \
                 DB.ElementTransformUtils.CopyElement(doc, source_legend_component.Id, initial_translation)[0]
             new_component = doc.GetElement(copy_component_id)
@@ -132,11 +146,12 @@ with revit.Transaction("Wall Types Legend"):
 
             new_component.get_Parameter(DB.BuiltInParameter.LEGEND_COMPONENT).Set(wall_type.Id)
             new_component.get_Parameter(DB.BuiltInParameter.LEGEND_COMPONENT_VIEW).Set(-8)
-            new_component.get_Parameter(DB.BuiltInParameter.LEGEND_COMPONENT_LENGTH).Set(line_length)
+            new_component.get_Parameter(DB.BuiltInParameter.LEGEND_COMPONENT_LENGTH).Set(LINE_LENGTH)
             wall_thickness = wall_type.Width
-            DB.ElementTransformUtils.MoveElement(doc, new_component.Id, location - DB.XYZ(0, wall_thickness/2, 0))
+            DB.ElementTransformUtils.MoveElement(doc, new_component.Id, location - DB.XYZ(0, wall_thickness / 2, 0))
             location = location.Add(offset)
 
+        # for Floor Plan views
         elif view.ViewType == DB.ViewType.FloorPlan:
             new_wall = place_wall(location, level)
             change_wall_type(new_wall, dict_walls[name])

--- a/pyChilizer.tab/Template.panel/template2.stack/List Walls.pushbutton/walltypesconfig.py
+++ b/pyChilizer.tab/Template.panel/template2.stack/List Walls.pushbutton/walltypesconfig.py
@@ -12,7 +12,8 @@ op.close_others()
 doc = revit.doc
 
 my_config = script.get_config()
-DEFAULT_LENGTH = units.round_metric_or_imperial(units.convert_length_to_display(5, doc), doc)
+DEFAULT_LENGTH = 5
+
 def get_text_types(doc):
     text_types = DB.FilteredElementCollector(
         doc).OfClass(DB.TextNoteType).ToElements()
@@ -22,19 +23,17 @@ def get_text_types(doc):
 
 def get_config(option, doc=revit.doc):
     try:
-        if option in ["line_length", "y_offset", "x_offset"]:
+        if option in [""]:
             return my_config.get_option(option, DEFAULT_LENGTH)
         else:
             return my_config.get_option(option)
     except AttributeError or Exceptions.AttributeErrorException:
-        if option == "line_length":
-            return DEFAULT_LENGTH
-        elif option == "y_offset":
-            return DEFAULT_LENGTH
-        elif option == "x_offset":
+        if option == "v_offset":
             return DEFAULT_LENGTH
         elif option == "text_style":
             return get_text_types(doc).values()[0]
+        elif option == "text_bold":
+            return False
         elif option == "include_buildup":
             return False
 
@@ -43,29 +42,28 @@ def rwp_ui_show(doc):
     text_styles_dict = get_text_types(doc)
     prev_text_style_id = DB.ElementId(get_config("text_style"))
     prev_text_style_name = database.get_name(doc.GetElement(prev_text_style_id))
+    v_offset_dict = ["Compact","Spaced"]
+
+
     if prev_text_style_name not in text_styles_dict.keys():
         prev_text_style_name = text_styles_dict.keys()[0]
     components = [
-        Label("Wall Length"),
-        TextBox(name="line_length", Text=units.convert_length_to_display_string(get_config("line_length", doc))),
-        Label("Y Offset"),
-        TextBox(name="y_offset", Text=units.convert_length_to_display_string(get_config("y_offset", doc))),
-        Label("X Offset"),
-        TextBox(name="x_offset", Text=units.convert_length_to_display_string(get_config("x_offset", doc))),
+        Label("Vertical Offset"),
+        ComboBox(name="v_offset_combobox", options=v_offset_dict),
         Label("Text Style"),
         ComboBox(name="text_style", options=text_styles_dict.keys(), default=prev_text_style_name),
-        CheckBox("include_buildup", "Include Wall Buildup (Wall layers, thickness, material)",
+        CheckBox("text_bold", "Text Bold",
                  default=bool(get_config("include_buildup"))),
+        CheckBox("include_buildup", "Include Wall Buildup (Wall layers, thickness, material)", default=bool(get_config("include_buildup"))),
         Button("Remember")
     ]
     form = FlexForm("Settings", components)
     ok = form.show()
     # assign chosen values
     if ok:
-        setattr(my_config, "line_length", units.convert_display_string_to_internal(form.values["line_length"], doc))
-        setattr(my_config, "y_offset", units.convert_display_string_to_internal(form.values["y_offset"], doc))
-        setattr(my_config, "x_offset", units.convert_display_string_to_internal(form.values["x_offset"], doc))
+        setattr(my_config, "v_offset", form.values["v_offset_combobox"])
         setattr(my_config, "text_style", text_styles_dict[(form.values["text_style"])])
+        setattr(my_config, "text_bold", int(form.values["text_bold"]))
         setattr(my_config, "include_buildup", int(form.values["include_buildup"]))
         script.save_config()
 


### PR DESCRIPTION


## Description
While switching from Metric to Imperial projects, the config UI wasn't always updating as expected which resulted in errors like 'distance over 16km'. 

## Changes
Removed the option of custom offsets and using two pre-defined options instead: Compact and Spaced.

## Related Issues
[List Wall Error Revit 2023 #61](https://github.com/dnenov/pyChilizer/issues/61)

## Checklist
- [x] Code follows the project's coding style
- [ ] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [ ] All automated tests are passing
- [ ] Reviewed by at least one team member

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/3397c222-ebc4-46ee-ad2a-81103436504b).

