### PR TITLE
skip opened sheets

### DIFF
--- a/pyChilizer.tab/Project.panel/Purge +.pulldown/Purge unused sheets.pushbutton/script.py
+++ b/pyChilizer.tab/Project.panel/Purge +.pulldown/Purge unused sheets.pushbutton/script.py
@@ -1,5 +1,5 @@
 __title__ = "Purge unused sheets"
-__doc__ = "Delete all the Sheets without Viewports on them."
+__doc__ = "Delete all the Sheets without Viewports on them, skipping opened sheets."
 
 from pyrevit import forms
 from pyrevit import revit, DB
@@ -10,14 +10,52 @@ doc = __revit__.ActiveUIDocument.Document
 
 cl = DB.FilteredElementCollector(doc)
 
-sheets = List[DB.ElementId]\
-    ([i.Id for i in cl.OfClass(DB.ViewSheet).WhereElementIsNotElementType() if len(i.GetAllViewports()) == 0])
+# Get all empty sheets
+all_empty_sheets = [i for i in cl.OfClass(DB.ViewSheet).WhereElementIsNotElementType() if len(i.GetAllViewports()) == 0]
 
-message = 'There are {} empty Sheets in the current model. Are you sure you want to delete them?'.format(str(len(sheets)))
+# Get currently opened views in the active document
+open_views = []
+try:
+    for ui_view in uidoc.GetOpenUIViews():
+        open_views.append(ui_view.ViewId)
+except:
+    pass
 
-if len(sheets) == 0:
+# Also check the active view
+active_view_id = uidoc.ActiveView.Id
+
+# Filter out sheets that are currently opened
+sheets_to_delete = []
+opened_sheets_skipped = []
+
+for sheet in all_empty_sheets:
+    is_in_open_views = sheet.Id in open_views
+    is_active_view = sheet.Id == active_view_id
+    is_opened = is_in_open_views or is_active_view
+    
+    if is_opened:
+        opened_sheets_skipped.append(sheet.Title)
+    else:
+        sheets_to_delete.append(sheet.Id)
+
+sheets = List[DB.ElementId](sheets_to_delete)
+
+if len(sheets) == 0 and len(opened_sheets_skipped) == 0:
     forms.alert("No empty Sheets, well done!")
+elif len(sheets) == 0 and len(opened_sheets_skipped) > 0:
+    forms.alert("All empty sheets are currently opened and will be skipped.")
 else:
+    message = 'There are {} empty Sheets in the current model.'.format(str(len(all_empty_sheets)))
+    if len(opened_sheets_skipped) > 0:
+        message += '\n\n{} opened sheets will be skipped:'.format(len(opened_sheets_skipped))
+        for sheet_name in opened_sheets_skipped[:5]:  # Show first 5
+            message += '\n- {}'.format(sheet_name)
+        if len(opened_sheets_skipped) > 5:
+            message += '\n... and {} more'.format(len(opened_sheets_skipped) - 5)
+        message += '\n\nAre you sure you want to delete the remaining {} sheets?'.format(len(sheets))
+    else:
+        message += ' Are you sure you want to delete them?'
+    
     if forms.alert(message, ok=False, yes=True, no=True, exitscript=True):
         with revit.Transaction(__title__):
             try:
@@ -27,6 +65,11 @@ else:
                 print("SHEETS DELETED:\n")
                 for s in s_names:
                     print("{}".format(s))
+                
+                if len(opened_sheets_skipped) > 0:
+                    print("\nSHEETS SKIPPED (currently opened):\n")
+                    for s in opened_sheets_skipped:
+                        print("{}".format(s))
             except:
                 forms.alert("Could not execute the script (make sure there are no active empty Sheets).")
 


### PR DESCRIPTION
## Description
This PR addresses https://github.com/pyrevitlabs/pyRevit/issues/2282 - Wipe Option: Purge unused Revit Sheets which deletes all Sheets without Viewport on them except for the Sheet that I have open #2282

## Changes
- now will skip opened sheets

## Related Issues
[Reference any related GitHub issues or pull requests by mentioning their numbers.](https://github.com/pyrevitlabs/pyRevit/issues/2282)

## Checklist
- [ ] Code follows the project's coding style
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [ ] All automated tests are passing
- [ ] Reviewed by at least one team member

## Screenshots (if applicable)
<img width="393" height="316" alt="image" src="https://github.com/user-attachments/assets/3ea9fa54-b1cc-4d99-8ab6-ec03e446d7ec" />

## Additional Notes (if any)
Add any additional information or context that may be relevant to reviewers.
